### PR TITLE
No 403 override

### DIFF
--- a/apache/noindex.html
+++ b/apache/noindex.html
@@ -70,8 +70,8 @@
     <h1><span class="glyphicon glyphicon-ok-circle green" aria-hidden="true"></span> Tugboat is up and running!</h1>
 
     <p>
-    You're almost there! You are looking at an active Tugboat Preview with a copy of your code repository.If
-    you are seeing this page, you are probably either missing a build script, or it still needs some work.
+    You're almost there! You are looking at an active Tugboat Preview with a copy of your code repository.
+    If you are seeing this page, you are probably either missing a build script, or it still needs some work.
     </p>
 
     <p>Check out our <a href="https://docs.tugboat.qa">documentation</a> for more information about how Tugboat works with build scripts.</p>

--- a/apache/sites-available/000-default.conf
+++ b/apache/sites-available/000-default.conf
@@ -35,16 +35,19 @@
 
 	SetEnvIf X-Forwarded-Proto "^https" HTTPS=on
 
-        # Show a Tugboat splash screen for unconfigured subdomain previews
-        Alias /__tugboat /var/www/__tugboat
-        ErrorDocument 403 /__tugboat/noindex.html
+    # Show a Tugboat splash screen for unconfigured previews
+    Alias /__tugboat /var/www/__tugboat
+    RewriteEngine On
 
-        # Show a Tugboat splash screen for unconfigured subpath previews
-        RewriteEngine On
-        RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_URI} !-f
-        RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_URI} !-d
-        RewriteCond expr "%{REQUEST_URI} == '/%{ENV:TUGBOAT_PREVIEW}-%{ENV:TUGBOAT_TOKEN}'"
-        RewriteRule ^ /__tugboat/noindex.html [PT]
+    RewriteCond %{DOCUMENT_ROOT} !-f
+    RewriteCond %{DOCUMENT_ROOT} !-d
+    RewriteRule ^ /__tugboat/noindex.html [L,PT]
+
+    RewriteCond expr "%{REQUEST_URI} == '/%{ENV:TUGBOAT_PREVIEW}-%{ENV:TUGBOAT_TOKEN}'" [OR]
+    RewriteCond expr "%{REQUEST_URI} == '/%{ENV:TUGBOAT_PREVIEW}-%{ENV:TUGBOAT_TOKEN}/'"
+    RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_URI} !-f
+    RewriteCond %{DOCUMENT_ROOT}/%{REQUEST_URI} !-d
+    RewriteRule ^ /__tugboat/noindex.html [L,PT]
 </VirtualHost>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
Display the tugboat splash screen without overriding the global 403 header.

The logic here works as follows

```
If ($DOCUMENT_ROOT does not exist) {
    return splash
} else if ($REQUEST is for the root of a tugboat subpath preview, and the subpath does not exist {
    return splash
}
```