### PR TITLE
Add a shared Makefile to be able to include in project Makefiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           name: Test cleanup
           command: |
-            docker run localhost:5000/baseimage:latest sh -cx '
+            docker run localhost:5000/baseimage:latest sh -cex '
               ! test -e /bd_build
               ! ls /tmp/* 2>/dev/null
               ! ls /var/tmp/* 2>/dev/null

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,12 @@ jobs:
             apk add build-base
             make
   test:
+    working_directory: /app
     docker:
-      - image: q0rban/tugboat-baseimage:0.0.1
+      - image: q0rban/tugboat-baseimage:0.0.2
     steps:
+      - checkout
+      # Test that Locales are configured correctly.
       - run:
           name: Test locales
           command: |
@@ -41,11 +44,15 @@ jobs:
             set -x
             ! test -e /bd_build
             # We can't test /tmp because CircleCI puts stuff here.
-            # test -n $(shopt -s nullglob; echo /tmp/*)
-            test -n $(shopt -s nullglob; echo /var/tmp/*)
-            test -n $(shopt -s nullglob; echo /var/lib/apt/lists/*)
+            #! ls /tmp/* 2>/dev/null
+            ! ls /var/tmp/* 2>/dev/null
+            ! ls /var/lib/apt/lists/* 2>/dev/null
             ! test -e /etc/dpkg/dpkg.cfg.d/02apt-speedup
-            test -n $(shopt -s nullglob; echo /etc/ssh/ssh_host_*)
+            ! ls /etc/ssh/ssh_host_* 2>/dev/null
+      # Test the included Makefile.
+      - run:
+          name: Test Tugboat Makefile
+          command: make -C /app/.circleci/test test
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,14 +57,6 @@ jobs:
 
 workflows:
   version: 2
-  build:
-    jobs:
-      - build
-    # Only build on the master branch, because it takes forever to complete.
-    filter:
-      branches:
-        only:
-          - master
   test:
     jobs:
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,50 +13,59 @@ jobs:
             apk update
             apk add build-base
             make
-  test:
+  test-baseimage:
     working_directory: /app
     docker:
-      - image: q0rban/tugboat-baseimage:0.0.2
+      - image: docker:17.05.0-ce-git
     steps:
       - checkout
+      - setup_remote_docker
+      - run:
+          name: Build baseimage
+          command: |
+            apk update
+            apk add build-base
+            make baseimage
       # Test that Locales are configured correctly.
       - run:
           name: Test locales
           command: |
             set -x
-            locale -a | grep ^en_US$
-            locale -a | grep ^en_US\.utf8$
+            docker run localhost:5000/baseimage:latest locale -a | grep ^en_US$
+            docker run localhost:5000/baseimage:latest locale -a | grep ^en_US\.utf8$
       # Test that upstart is diverted to /bin/true.
       # See baseimage/prepare.sh.
       - run:
           name: Test upstart
-          command: /sbin/initctl
+          command: docker run localhost:5000/baseimage:latest /sbin/initctl
       # Test that ischroot is diverted to /bin/true.
       # See baseimage/prepare.sh.
       - run:
           name: Test ischroot
-          command: /usr/bin/ischroot
+          command: docker run localhost:5000/baseimage:latest /usr/bin/ischroot
       # Test that the cleanup script did what we expect.
       # See baseimage/cleanup.sh
       - run:
           name: Test cleanup
           command: |
-            set -x
-            ! test -e /bd_build
-            # We can't test /tmp because CircleCI puts stuff here.
-            #! ls /tmp/* 2>/dev/null
-            ! ls /var/tmp/* 2>/dev/null
-            ! ls /var/lib/apt/lists/* 2>/dev/null
-            ! test -e /etc/dpkg/dpkg.cfg.d/02apt-speedup
-            ! ls /etc/ssh/ssh_host_* 2>/dev/null
+            docker run localhost:5000/baseimage:latest sh -cx '
+              ! test -e /bd_build
+              ! ls /tmp/* 2>/dev/null
+              ! ls /var/tmp/* 2>/dev/null
+              ! ls /var/lib/apt/lists/* 2>/dev/null
+              ! test -e /etc/dpkg/dpkg.cfg.d/02apt-speedup
+              ! ls /etc/ssh/ssh_host_* 2>/dev/null'
       # Test the included Makefile.
       - run:
           name: Test Tugboat Makefile
-          command: make -C /app/.circleci/test test
+          command: |
+            docker create -v /tests --name test-container localhost:5000/baseimage:latest /bin/true
+            docker cp /app/.circleci/test/* test-container:/tests
+            docker run --volumes-from test-container localhost:5000/baseimage:latest make -C /tests test
 
 
 workflows:
   version: 2
   test:
     jobs:
-      - test
+      - test-baseimage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,47 +21,11 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Build baseimage
+          name: Run image tests
           command: |
             apk update
             apk add build-base
-            make baseimage
-      # Test that Locales are configured correctly.
-      - run:
-          name: Test locales
-          command: |
-            set -x
-            docker run localhost:5000/baseimage:latest locale -a | grep ^en_US$
-            docker run localhost:5000/baseimage:latest locale -a | grep ^en_US\.utf8$
-      # Test that upstart is diverted to /bin/true.
-      # See baseimage/prepare.sh.
-      - run:
-          name: Test upstart
-          command: docker run localhost:5000/baseimage:latest /sbin/initctl
-      # Test that ischroot is diverted to /bin/true.
-      # See baseimage/prepare.sh.
-      - run:
-          name: Test ischroot
-          command: docker run localhost:5000/baseimage:latest /usr/bin/ischroot
-      # Test that the cleanup script did what we expect.
-      # See baseimage/cleanup.sh
-      - run:
-          name: Test cleanup
-          command: |
-            docker run localhost:5000/baseimage:latest sh -cex '
-              ! test -e /bd_build
-              ! ls /tmp/* 2>/dev/null
-              ! ls /var/tmp/* 2>/dev/null
-              ! ls /var/lib/apt/lists/* 2>/dev/null
-              ! test -e /etc/dpkg/dpkg.cfg.d/02apt-speedup
-              ! ls /etc/ssh/ssh_host_* 2>/dev/null'
-      # Test the included Makefile.
-      - run:
-          name: Test Tugboat Makefile
-          command: |
-            docker create -v /tests --name test-container localhost:5000/baseimage:latest /bin/true
-            docker cp /app/.circleci/test/* test-container:/tests
-            docker run --volumes-from test-container localhost:5000/baseimage:latest make -C /tests test
+            make test-all
 
 
 workflows:

--- a/.circleci/test/Makefile
+++ b/.circleci/test/Makefile
@@ -10,18 +10,21 @@ test:
 	$(MAKE) install-package-wget
 	hash wget
 	apt-get remove wget -y
+	@printf "Test passed.\n\n"
 
 	######
 	# Test install-php-7.2 (install-php-%)
 	! hash php 2>/dev/null
 	$(MAKE) install-php-7.2
 	php -v | grep ^PHP\ 7\.2
+	@printf "Test passed.\n\n"
 
 	######
 	# Test install-composer
 	! hash composer 2>/dev/null
 	$(MAKE) install-composer
 	hash composer
+	@printf "Test passed.\n\n"
 
 	######
 	# Test install-drush-launcher
@@ -30,18 +33,21 @@ test:
 	hash drush
 	drush --version | grep '^The Drush launcher'
 	rm /usr/bin/drush
+	@printf "Test passed.\n\n"
 
 	######
 	# Test install-drush
 	! hash drush 2>/dev/null
 	$(MAKE) install-drush
 	hash drush
+	@printf "Test passed.\n\n"
 
 	######
 	# Test install-terminus
 	! hash terminus 2>/dev/null
 	$(MAKE) install-terminus
 	hash terminus
+	@printf "Test passed.\n\n"
 
 	######
 	# Test install-nodejs-8 (install-nodejs-%)
@@ -49,3 +55,6 @@ test:
 	$(MAKE) install-nodejs-8
 	hash nodejs
 	nodejs --version | grep ^v8
+	@printf "Test passed.\n\n"
+
+	@echo "All Makefile tests passed."

--- a/.circleci/test/Makefile
+++ b/.circleci/test/Makefile
@@ -1,0 +1,51 @@
+# Test the Tugboat Makefile
+
+include /usr/share/tugboat/Makefile
+
+.PHONY: test
+test:
+	######
+	# Test install-package-wget (install-package-%)
+	! hash wget 2>/dev/null
+	$(MAKE) install-package-wget
+	hash wget
+	apt-get remove wget -y
+
+	######
+	# Test install-php-7.2 (install-php-%)
+	! hash php 2>/dev/null
+	$(MAKE) install-php-7.2
+	php -v | grep ^PHP\ 7\.2
+
+	######
+	# Test install-composer
+	! hash composer 2>/dev/null
+	$(MAKE) install-composer
+	hash composer
+
+	######
+	# Test install-drush-launcher
+	! hash drush 2>/dev/null
+	$(MAKE) install-drush-launcher
+	hash drush
+	drush --version | grep '^The Drush launcher'
+	rm /usr/bin/drush
+
+	######
+	# Test install-drush
+	! hash drush 2>/dev/null
+	$(MAKE) install-drush
+	hash drush
+
+	######
+	# Test install-terminus
+	! hash terminus 2>/dev/null
+	$(MAKE) install-terminus
+	hash terminus
+
+	######
+	# Test install-nodejs-8 (install-nodejs-%)
+	! hash nodejs 2>/dev/null
+	$(MAKE) install-nodejs-8
+	hash nodejs
+	nodejs --version | grep ^v8

--- a/.circleci/test/Makefile
+++ b/.circleci/test/Makefile
@@ -5,6 +5,12 @@ include /usr/share/tugboat/Makefile
 .PHONY: test
 test:
 	######
+	# Test _help and _targets
+	$(MAKE) _help | grep /usr/share/tugboat/Makefile > /dev/null
+	$(MAKE) _targets | grep install-package-% > /dev/null
+	@printf "Test passed.\n\n"
+
+	######
 	# Test install-package-wget (install-package-%)
 	! hash wget 2>/dev/null
 	$(MAKE) install-package-wget

--- a/Makefile
+++ b/Makefile
@@ -44,19 +44,19 @@ test-baseimage: baseimage
 	# Test locales are configured properly.
 	docker run localhost:5000/baseimage:latest locale -a | grep ^en_US$$
 	docker run localhost:5000/baseimage:latest locale -a | grep ^en_US\.utf8$$
-	@echo "Test passed.\n"
+	@printf "Test passed.\n\n"
 
 	######
 	# Test that upstart is diverted to /bin/true.
 	# See baseimage/prepare.sh.
 	docker run localhost:5000/baseimage:latest /sbin/initctl
-	@echo "Test passed.\n"
+	@printf "Test passed.\n\n"
 
 	######
 	# Test that ischroot is diverted to /bin/true.
 	# See baseimage/prepare.sh.
 	docker run localhost:5000/baseimage:latest /usr/bin/ischroot
-	@echo "Test passed.\n"
+	@printf "Test passed.\n\n"
 
 	######
 	# Test that the cleanup script did what we expect.
@@ -68,7 +68,7 @@ test-baseimage: baseimage
 		! ls /var/lib/apt/lists/* 2>/dev/null; \
 		! test -e /etc/dpkg/dpkg.cfg.d/02apt-speedup; \
 		! ls /etc/ssh/ssh_host_* 2>/dev/null'
-	@echo "Test passed.\n"
+	@printf "Test passed.\n\n"
 
 	######
 	# Test the included Makefile.
@@ -76,6 +76,6 @@ test-baseimage: baseimage
 	docker cp .circleci/test/* baseimage-test-container:/tests
 	docker run --volumes-from baseimage-test-container localhost:5000/baseimage:latest make -C /tests test
 	docker rm baseimage-test-container
-	@echo "Test passed.\n"
+	@printf "Test passed.\n\n"
 
-	@echo "All tests passed!"
+	@echo "All baseimage tests passed!"

--- a/baseimage/Dockerfile
+++ b/baseimage/Dockerfile
@@ -6,6 +6,9 @@ ADD . /bd_build
 RUN /bd_build/prepare.sh && \
 	/bd_build/system_services.sh && \
 	/bd_build/utilities.sh && \
-	/bd_build/cleanup.sh
+	/bd_build/cleanup.sh && \
+	mkdir -p /usr/share/tugboat
+
+COPY Makefile /usr/share/tugboat/Makefile
 
 CMD ["/sbin/my_init"]

--- a/baseimage/Makefile
+++ b/baseimage/Makefile
@@ -1,5 +1,8 @@
-.PHONY: usage
-usage:
+# The usage below is indented so that if you call `make` or `make usage`, on
+# this file, it will output it from that target as well as being readable from
+# the file directly.
+.PHONY: _help
+_help: ## Print out the help for this Makefile include.
 	# This Makefile is intended to be used as an include inside of a Makefile
 	# for your Tugboat project. To include it, place the following line at the
 	# top of your Makefile:
@@ -9,7 +12,7 @@ usage:
 	# Make sure to keep the hyphen at the beginning of the include if you want
 	# your Makefile to work on non-Tugboat environments.
 	#
-	# Alternately, you can call `$(MAKE) -C /usr/share/tugboat foo` from within
+	# Alternately, you can call '$$(MAKE) -C /usr/share/tugboat foo' from within
 	# a target if you don't want to include this Makefile in its entirety.
 	#
 	# Once the file is included in your Makefile, you can then use the targets
@@ -28,15 +31,27 @@ usage:
 	#
 	# You might expect that running `make baz` would result in foo being output
 	# twice, since baz calls bar which prints both foo and bar, but it doesn't.
-	# It knows it's already run foo when it gets to bar.
+	# It knows it's already run foo when it gets to bar. This means that if both
+	# composer and the drush-launcher require the wget package, apt-get will
+	# get called only once.
 	#
 	# To learn more about Make syntax:
 	#  - http://makefiletutorial.com/
 	#  - http://www.gnu.org/software/make/manual/make.html
 	#  - https://gist.github.com/isaacs/62a2d1825d04437c6f08
-	@true
-# The usage above is indented so that if you call `make` or `make usage`, on
-# this file, it will output it from that target as well.
+	#
+	# Allowed targets:
+	@$(MAKE) _targets
+
+# To add a target to the help, add a double comment (##) on the target line.
+.PHONY: _targets
+_targets: ## Print out the available targets in this include.
+# 	# The code below was adapted to allow for targets with % in them and to
+#	# continue to work even as an include. The original concept was taken from
+# 	# https://github.com/nodejs/node/blob/f05eaa4a537ed7ef57814d951d64c25ef2844720/Makefile#L73-L78.
+	@printf "For more targets and info see the comments in the Makefile.\n\n"
+	@grep -E '^[a-zA-Z0-9%._-]+:.*?## .*$$' $(dir $(lastword $(MAKEFILE_LIST)))Makefile | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
 
 # We need bash to use =~ regex tests in if statements.
 SHELL := /bin/bash
@@ -54,19 +69,19 @@ current_php_version = $(shell php -r "echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_V
 # To keep build times faster, we can run apt-get update just once by having this
 # as a dependency to install-package-%.
 .PHONY: packages-update
-packages-update:
+packages-update: ## Gets information on the newest versions of packages and their dependencies.
 	apt-get update
 
 # Install an apt package by passing the value. For example, to install wget, use
 # install-package-wget as the target.
 .PHONY: install-package-%
-install-package-%: packages-update
+install-package-%: packages-update ## Install a specific package on this distro by replacing %, e.g. install-package-wget.
 	apt-get install -y --no-install-recommends $(*)
 
 # Installs the latest version of Composer. Note, you should use install-php-%
 # first to ensure your desired version of PHP is installed.
 .PHONY: install-composer
-install-composer: install-package-wget
+install-composer: install-package-wget ## Installs the latest version of Composer.
 	$(info Installing Composer...)
 #	# The following code is adapted from https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
 	wget -O composer-setup.php https://getcomposer.org/installer
@@ -83,7 +98,7 @@ install-composer: install-package-wget
 
 # Installs the latest version of drush.
 .PHONY: install-drush
-install-drush: install-composer install-package-rsync
+install-drush: install-composer install-package-rsync ## Installs the latest version of drush.
 	$(info Installing Drush...)
 	composer --no-ansi global require drush/drush
 	ln -sf /root/.composer/vendor/bin/drush /usr/bin/drush
@@ -91,7 +106,7 @@ install-drush: install-composer install-package-rsync
 
 # Installs the drush-launcher instead of drush.
 .PHONY: install-drush-launcher
-install-drush-launcher: install-package-wget
+install-drush-launcher: install-package-wget ## Installs the drush-launcher instead of drush.
 	$(info Installing Drush Launcher...)
 	wget -O /tmp/drush.phar https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
 	mv -f /tmp/drush.phar /usr/bin/drush
@@ -100,7 +115,7 @@ install-drush-launcher: install-package-wget
 
 # Install terminus for Pantheon sites.
 .PHONY: install-terminus
-install-terminus: install-composer install-package-rsync
+install-terminus: install-composer install-package-rsync ## Install terminus for Pantheon sites.
 	$(info Installing Terminus...)
 	curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar
 	php installer.phar install
@@ -109,7 +124,7 @@ install-terminus: install-composer install-package-rsync
 # Install a specific version of PHP by passing the version to this target. Use
 # major and minor versions separated by a dot. For example, install-php-7.2.
 .PHONY: install-php-%
-install-php-%:
+install-php-%: ## Install a specific version of PHP by replacing the %, e.g. install-php-7.2.
 	$(info Installing PHP $*...)
 #	# Ensure PHP version is correctly formatted.
 	@if [[ ! $* =~ ^[0-9]\.[0-9]$$ ]]; then\
@@ -156,7 +171,7 @@ install-php-%:
 # Install a specific version of nodejs by passing the version to this target.
 # Use the major version only. For example, install-nodejs-9.
 .PHONY: install-nodejs-%
-install-nodejs-%: install-package-curl
+install-nodejs-%: install-package-curl ## Install a specific version of nodejs by replacing the %, e.g. install-nodejs-8.
 	$(info Installing nodejs $*...)
 #	# Ensure nodejs version is correctly formatted.
 	@if [[ ! $* =~ ^[0-9]$$ ]]; then\

--- a/baseimage/Makefile
+++ b/baseimage/Makefile
@@ -125,10 +125,6 @@ install-php-%:
 		apt-get update;\
 		apt-get install -y \
 			php$(*) \
-			php$(*)-mbstring \
-			php$(*)-mysql \
-			php$(*)-xml \
-			php$(*)-zip \
 			php$(*)-bcmath \
 			php$(*)-bz2 \
 			php$(*)-cli \

--- a/baseimage/Makefile
+++ b/baseimage/Makefile
@@ -1,0 +1,172 @@
+.PHONY: usage
+usage:
+	# This Makefile is intended to be used as an include inside of a Makefile
+	# for your Tugboat project. To include it, place the following line at the
+	# top of your Makefile:
+	#
+	# -include /usr/share/tugboat/Makefile
+	#
+	# Make sure to keep the hyphen at the beginning of the include if you want
+	# your Makefile to work on non-Tugboat environments.
+	#
+	# Alternately, you can call `$(MAKE) -C /usr/share/tugboat foo` from within
+	# a target if you don't want to include this Makefile in its entirety.
+	#
+	# Once the file is included in your Makefile, you can then use the targets
+	# in this file to do things like install packages, install Drush, install a
+	# specific version of PHP or nodejs, etc. The advantage to using Make to
+	# handle these things is that it knows if a target has already run so that
+	# it won't run it more than once. For example, consider the following
+	# Makefile:
+	#
+	# foo:
+	# 	echo "foo"
+	# bar: foo
+	# 	echo "bar"
+	# baz: foo bar
+	# 	echo "baz"
+	#
+	# You might expect that running `make baz` would result in foo being output
+	# twice, since baz calls bar which prints both foo and bar, but it doesn't.
+	# It knows it's already run foo when it gets to bar.
+	#
+	# To learn more about Make syntax:
+	#  - http://makefiletutorial.com/
+	#  - http://www.gnu.org/software/make/manual/make.html
+	#  - https://gist.github.com/isaacs/62a2d1825d04437c6f08
+	@true
+# The usage above is indented so that if you call `make` or `make usage`, on
+# this file, it will output it from that target as well.
+
+# We need bash to use =~ regex tests in if statements.
+SHELL := /bin/bash
+# Turn off interactive mode in Composer for all subshells.
+export COMPOSER_NO_INTERACTION := 1
+
+# Local variables below. Keep local variables lowercase to differentiate.
+# A macro to retrieve the composer signature. This uses a recursively expanded
+# assignment so that it's only evaluated if needed.
+composer_expected_signature = $(shell wget -q -O - https://composer.github.io/installer.sig)
+# Determine the current PHP version in MAJOR.MINOR format. We use a recursively
+# expanded variable so that it's only evaluated if we want the value.
+current_php_version = $(shell php -r "echo PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;" 2>/dev/null)
+
+# To keep build times faster, we can run apt-get update just once by having this
+# as a dependency to install-package-%.
+.PHONY: packages-update
+packages-update:
+	apt-get update
+
+# Install an apt package by passing the value. For example, to install wget, use
+# install-package-wget as the target.
+.PHONY: install-package-%
+install-package-%: packages-update
+	apt-get install -y --no-install-recommends $(*)
+
+# Installs the latest version of Composer. Note, you should use install-php-%
+# first to ensure your desired version of PHP is installed.
+.PHONY: install-composer
+install-composer: install-package-wget
+	$(info Installing Composer...)
+#	# The following code is adapted from https://getcomposer.org/doc/faqs/how-to-install-composer-programmatically.md
+	wget -O composer-setup.php https://getcomposer.org/installer
+	@if ! sha384sum composer-setup.php | grep ${composer_expected_signature}; then \
+		>&2 echo 'ERROR: Invalid installer signature'; \
+		rm composer-setup.php; \
+		exit 1; \
+	fi
+
+	php composer-setup.php --install-dir=/tmp
+	mv -f /tmp/composer.phar /usr/local/bin/composer
+	rm composer-setup.php
+	@echo "Composer installed."
+
+# Installs the latest version of drush.
+.PHONY: install-drush
+install-drush: install-composer install-package-rsync
+	$(info Installing Drush...)
+	composer --no-ansi global require drush/drush
+	ln -sf /root/.composer/vendor/bin/drush /usr/bin/drush
+	@echo "Drush installed."
+
+# Installs the drush-launcher instead of drush.
+.PHONY: install-drush-launcher
+install-drush-launcher: install-package-wget
+	$(info Installing Drush Launcher...)
+	wget -O /tmp/drush.phar https://github.com/drush-ops/drush-launcher/releases/download/0.6.0/drush.phar
+	mv -f /tmp/drush.phar /usr/bin/drush
+	chmod +x /usr/bin/drush
+	@echo "Drush Launcher installed."
+
+# Install terminus for Pantheon sites.
+.PHONY: install-terminus
+install-terminus: install-composer install-package-rsync
+	$(info Installing Terminus...)
+	curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar
+	php installer.phar install
+	@echo "Terminus installed."
+
+# Install a specific version of PHP by passing the version to this target. Use
+# major and minor versions separated by a dot. For example, install-php-7.2.
+.PHONY: install-php-%
+install-php-%:
+	$(info Installing PHP $*...)
+#	# Ensure PHP version is correctly formatted.
+	@if [[ ! $* =~ ^[0-9]\.[0-9]$$ ]]; then\
+		echo "PHP version $* is an invalid format.";\
+		exit 1;\
+	fi
+#	# Ensure installed PHP version isn't the current version to be installed.
+	@if [ $* = ${current_php_version} ]; then\
+		echo "Current PHP Version is already ${current_php_version}.";\
+	else \
+		apt-get install -y python-software-properties software-properties-common;\
+		LC_ALL=C.UTF-8 add-apt-repository -y ppa:ondrej/php;\
+		apt-get update;\
+		apt-get install -y \
+			php$(*) \
+			php$(*)-mbstring \
+			php$(*)-mysql \
+			php$(*)-xml \
+			php$(*)-zip \
+			php$(*)-bcmath \
+			php$(*)-bz2 \
+			php$(*)-cli \
+			php$(*)-common \
+			php$(*)-curl \
+			php$(*)-dev \
+			php$(*)-gd \
+			php$(*)-intl \
+			php$(*)-json \
+			php$(*)-mbstring \
+			php$(*)-mysql \
+			php$(*)-opcache \
+			php$(*)-phpdbg \
+			php$(*)-pspell \
+			php$(*)-readline \
+			php$(*)-recode \
+			php$(*)-soap \
+			php$(*)-sqlite3 \
+			php$(*)-tidy \
+			php$(*)-xml \
+			php$(*)-xsl \
+			php$(*)-zip \
+			libapache2-mod-php$(*);\
+		a2enmod php$(*);\
+		a2dismod php$(current_php_version) || /bin/true;\
+		echo "PHP $(*) installed.";\
+	fi
+
+# Install a specific version of nodejs by passing the version to this target.
+# Use the major version only. For example, install-nodejs-9.
+.PHONY: install-nodejs-%
+install-nodejs-%: install-package-curl
+	$(info Installing nodejs $*...)
+#	# Ensure nodejs version is correctly formatted.
+	@if [[ ! $* =~ ^[0-9]$$ ]]; then\
+		echo "Version number $* is an invalid format. Specify the major version only.";\
+		exit 1;\
+	fi
+	curl -sL https://deb.nodesource.com/setup_$(*).x | bash -
+	$(MAKE) install-package-nodejs
+	@echo "Installed nodejs $(*).x."

--- a/baseimage/Makefile
+++ b/baseimage/Makefile
@@ -1,46 +1,33 @@
-# The usage below is indented so that if you call `make` or `make usage`, on
-# this file, it will output it from that target as well as being readable from
-# the file directly.
+# Note for readers reading the source. $$(MAKE) should be $(MAKE). It is double
+# dollared to allow for printing this define in 'make _help'.
+define HELP_TEXT
+This Makefile is intended to be used as an include inside of a Makefile for your
+Tugboat project. To include it, place the following line at the top of your
+Makefile:
+
+-include /usr/share/tugboat/Makefile
+
+Make sure to keep the hyphen at the beginning of the include if you want your
+Makefile to work on non-Tugboat environments.
+
+Alternately, you can call '$$(MAKE) -C /usr/share/tugboat foo' from within a
+target if you don't want to include this Makefile in its entirety.
+
+After you've included it, you may call 'make _targets' to see the available
+targets to use.
+
+To learn more about Make syntax:
+ - http://makefiletutorial.com/
+ - http://www.gnu.org/software/make/manual/make.html
+ - https://gist.github.com/isaacs/62a2d1825d04437c6f08
+
+------------
+endef
+export HELP_TEXT
+
 .PHONY: _help
 _help: ## Print out the help for this Makefile include.
-	# This Makefile is intended to be used as an include inside of a Makefile
-	# for your Tugboat project. To include it, place the following line at the
-	# top of your Makefile:
-	#
-	# -include /usr/share/tugboat/Makefile
-	#
-	# Make sure to keep the hyphen at the beginning of the include if you want
-	# your Makefile to work on non-Tugboat environments.
-	#
-	# Alternately, you can call '$$(MAKE) -C /usr/share/tugboat foo' from within
-	# a target if you don't want to include this Makefile in its entirety.
-	#
-	# Once the file is included in your Makefile, you can then use the targets
-	# in this file to do things like install packages, install Drush, install a
-	# specific version of PHP or nodejs, etc. The advantage to using Make to
-	# handle these things is that it knows if a target has already run so that
-	# it won't run it more than once. For example, consider the following
-	# Makefile:
-	#
-	# foo:
-	# 	echo "foo"
-	# bar: foo
-	# 	echo "bar"
-	# baz: foo bar
-	# 	echo "baz"
-	#
-	# You might expect that running `make baz` would result in foo being output
-	# twice, since baz calls bar which prints both foo and bar, but it doesn't.
-	# It knows it's already run foo when it gets to bar. This means that if both
-	# composer and the drush-launcher require the wget package, apt-get will
-	# get called only once.
-	#
-	# To learn more about Make syntax:
-	#  - http://makefiletutorial.com/
-	#  - http://www.gnu.org/software/make/manual/make.html
-	#  - https://gist.github.com/isaacs/62a2d1825d04437c6f08
-	#
-	# Allowed targets:
+	@printf "$$HELP_TEXT\n"
 	@$(MAKE) _targets
 
 # To add a target to the help, add a double comment (##) on the target line.
@@ -49,16 +36,21 @@ _targets: ## Print out the available targets in this include.
 # 	# The code below was adapted to allow for targets with % in them and to
 #	# continue to work even as an include. The original concept was taken from
 # 	# https://github.com/nodejs/node/blob/f05eaa4a537ed7ef57814d951d64c25ef2844720/Makefile#L73-L78.
-	@printf "For more targets and info see the comments in the Makefile.\n\n"
-	@grep -E '^[a-zA-Z0-9%._-]+:.*?## .*$$' $(dir $(lastword $(MAKEFILE_LIST)))Makefile | sort | \
+	@printf "Available targets:\n\n"
+	@grep -E '^[a-zA-Z0-9%._-]+:.*?## .*$$' $(makefile_path) | sort | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-15s\033[0m %s\n", $$1, $$2}'
+	@printf "\nFor more targets and info see the comments in the Makefile.\n"
 
 # We need bash to use =~ regex tests in if statements.
 SHELL := /bin/bash
 # Turn off interactive mode in Composer for all subshells.
 export COMPOSER_NO_INTERACTION := 1
 
+#######
 # Local variables below. Keep local variables lowercase to differentiate.
+#
+# Determine the path to this file.
+makefile_path := $(dir $(lastword $(MAKEFILE_LIST)))Makefile
 # A macro to retrieve the composer signature. This uses a recursively expanded
 # assignment so that it's only evaluated if needed.
 composer_expected_signature = $(shell wget -q -O - https://composer.github.io/installer.sig)

--- a/baseimage/utilities.sh
+++ b/baseimage/utilities.sh
@@ -4,7 +4,7 @@ source /bd_build/buildconfig
 set -x
 
 ## Often used tools.
-$minimal_apt_get_install curl less vim-tiny psmisc
+$minimal_apt_get_install curl less vim-tiny psmisc build-essential
 ln -s /usr/bin/vim.tiny /usr/bin/vim
 
 ## This tool runs a command as another user and sets $HOME.

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,7 +1,7 @@
 FROM localhost:5000/baseimage
 
 RUN apt-get update && \
-    apt-get -y --no-install-recommends install apt-transport-https build-essential curl git vim openssh-client && \
+    apt-get -y --no-install-recommends install apt-transport-https curl git vim openssh-client && \
     apt-get -y --no-install-recommends install realpath && \
     apt-get -y --no-install-recommends install ssmtp && \
     sed -i s/mailhub=mail/mailhub=172.17.42.1/ /etc/ssmtp/ssmtp.conf && \


### PR DESCRIPTION
The Makefile included in this PR will add some utility targets that webhead services can use easily accomplish common tasks, such as install a specific version of PHP, install Drush, or the Drush Launcher, install a specific version of nodejs, install Terminus. The thought here is that some of these commands are unique to the image. The `install-php-7.2` target would look different on a Debian image than it would on an Ubuntu image. But the net effect is the same for the Tugboat end-user. They just want a different version of PHP.

Testing instructions:
1. Checkout this branch
2. ~Run `make test-all`~ <-- Probably not necessary since CircleCI is doing this.
3. Run `cd baseimage`
4. Run `make _help` to see how it works.